### PR TITLE
解决异步任务状态回传时uid被覆盖的问题

### DIFF
--- a/transport/request.go
+++ b/transport/request.go
@@ -49,7 +49,9 @@ func NewRequest() *Request {
 	}
 	request.AddHeader(FromHeader, Client)
 	request.AddHeader(Pid, options.Opts.Pid)
-	request.AddHeader(Uid, options.Opts.Uid)
+	if options.Opts.Uid != "" {
+		request.AddHeader(Uid, options.Opts.Uid)
+	}
 	if options.Opts.Cid != "" {
 		request.AddHeader(Cid, options.Opts.Cid)
 	}


### PR DESCRIPTION
这里不建议将Uid直接放在Header中，在conn.asyncreport.ReportStatus的异步任务回传状态时，与任务的uid冲突，导致回传状态的uid为空。

覆盖步骤：
1、在NewRequest时，使用AddHeader设置uid。
https://github.com/chaosblade-io/chaosblade-box-agent/blob/main/transport/request.go#L52

2、在ReportStatus时，使用AddParam设置任务uid。
https://github.com/chaosblade-io/chaosblade-box-agent/blob/main/conn/asyncreport/asyncreport.go#L41

3、GetBody()获取请求体时，会将Header中的uid覆盖掉Param的uid。
https://github.com/chaosblade-io/chaosblade-box-agent/blob/main/pkg/http/http.go#L93C29-L93C46

4、最终导致第二步设置的uid丢失