### PR TITLE
fix: enhance agent external IP handling in Kubernetes collector

### DIFF
--- a/collector/kubernetes/common.go
+++ b/collector/kubernetes/common.go
@@ -66,7 +66,11 @@ func getServiceExternalIP(svc *v1.Service, wide bool) string {
 	return "<unknown>"
 }
 
-const loadBalancerWidth = 16
+const (
+	loadBalancerWidth = 16
+	// DefaultAgentServiceName is the default service name for chaos-agent
+	DefaultAgentServiceName = "chaos-agent"
+)
 
 // loadBalancerStatusStringer behaves mostly like a string interface and converts the given status to a string.
 // `wide` indicates whether the returned value is meant for --o=wide output. If not, it's clipped to 16 bytes.


### PR DESCRIPTION
- Introduced a constant for the default chaos-agent service name.
- Improved logic for setting the agent's external IP, including checks for empty and invalid IPs.
- Added logging for various scenarios, such as when the external IP is empty or invalid, and when multiple IPs are provided.

This update aims to ensure more robust handling of service external IPs in the Kubernetes environment.

chaosblade-io/chaosblade-box#205