### PR TITLE
refactor: remove unused cluster_type configuration from chaos-agent v…

### DIFF
--- a/build/helm3/chaos-agent-arm/templates/ahas_deployment.yaml
+++ b/build/helm3/chaos-agent-arm/templates/ahas_deployment.yaml
@@ -67,9 +67,6 @@ spec:
             {{- if .Values.controller.cluster_name }}
             - '--kubernetes.cluster.name={{ .Values.controller.cluster_name }}'
             {{- end }}
-            {{- if .Values.controller.cluster_type }}
-            - '--kubernetes.cluster.type={{ .Values.controller.cluster_type }}'
-            {{- end }}
             {{- if .Values.transport.endpoint }}
             - '--transport.endpoint={{ .Values.transport.endpoint }}'
             {{ end }}

--- a/build/helm3/chaos-agent-arm/values.yaml
+++ b/build/helm3/chaos-agent-arm/values.yaml
@@ -15,7 +15,6 @@
 # Default values for chaos.
 controller:
   # controller.region_id: The region where the cluster is located, currently only support cn-hangzhou, cn-beijing, cn-shenzhen, cn-shanghai and cn-public(public region)
-  cluster_type: ""
   # supported since 1.5.2 version
   cluster_id: ""
   cluster_name: ""

--- a/build/helm3/chaos-agent/templates/ahas_deployment.yaml
+++ b/build/helm3/chaos-agent/templates/ahas_deployment.yaml
@@ -67,9 +67,6 @@ spec:
             {{- if .Values.controller.cluster_name }}
             - '--kubernetes.cluster.name={{ .Values.controller.cluster_name }}'
             {{- end }}
-            {{- if .Values.controller.cluster_type }}
-            - '--kubernetes.cluster.type={{ .Values.controller.cluster_type }}'
-            {{- end }}
             {{- if .Values.transport.endpoint }}
             - '--transport.endpoint={{ .Values.transport.endpoint }}'
             {{ end }}

--- a/build/helm3/chaos-agent/values.yaml
+++ b/build/helm3/chaos-agent/values.yaml
@@ -15,7 +15,6 @@
 # Default values for chaos.
 controller:
   # controller.region_id: The region where the cluster is located, currently only support cn-hangzhou, cn-beijing, cn-shenzhen, cn-shanghai and cn-public(public region)
-  cluster_type: ""
   # supported since 1.5.2 version
   cluster_id: ""
   cluster_name: ""


### PR DESCRIPTION
…alues

Resolve chaosblade-io/chaosblade-box#162

- Eliminated the cluster_type field from the values.yaml files for both chaos-agent and chaos-agent-arm, as it was not being utilized.
- Updated the ahas_deployment.yaml templates to remove references to cluster_type, streamlining the deployment configuration.

This change simplifies the configuration and reduces potential confusion for users.