### PR TITLE
feat: add local IP configuration for chaos-agent and chaos-agent-arm

### DIFF
--- a/build/helm3/chaos-agent-arm/templates/ahas_deployment.yaml
+++ b/build/helm3/chaos-agent-arm/templates/ahas_deployment.yaml
@@ -70,6 +70,9 @@ spec:
             {{- if .Values.transport.endpoint }}
             - '--transport.endpoint={{ .Values.transport.endpoint }}'
             {{ end }}
+            {{- if .Values.controller.localIp }}
+            - '--localIp={{ .Values.controller.localIp }}'
+            {{- end }}
             - '--kubernetes.pod.report=true'
             - '--kubernetes.externalIp.enable={{ .Values.controller.externalIp_enable }}'
           securityContext:

--- a/build/helm3/chaos-agent-arm/values.yaml
+++ b/build/helm3/chaos-agent-arm/values.yaml
@@ -19,6 +19,9 @@ controller:
   cluster_id: ""
   cluster_name: ""
   externalIp_enable: false
+  # controller.localIp: Specify the agent IP address (useful when host has multiple IPs)
+  # If set, this IP will have the highest priority and will be used for all Agent-Box communications
+  localIp: ""
 
 # the image repository is related to the running env"
 images:

--- a/build/helm3/chaos-agent/templates/ahas_deployment.yaml
+++ b/build/helm3/chaos-agent/templates/ahas_deployment.yaml
@@ -70,6 +70,9 @@ spec:
             {{- if .Values.transport.endpoint }}
             - '--transport.endpoint={{ .Values.transport.endpoint }}'
             {{ end }}
+            {{- if .Values.controller.localIp }}
+            - '--localIp={{ .Values.controller.localIp }}'
+            {{- end }}
             - '--kubernetes.pod.report=true'
             - '--kubernetes.externalIp.enable={{ .Values.controller.externalIp_enable }}'
           securityContext:

--- a/build/helm3/chaos-agent/values.yaml
+++ b/build/helm3/chaos-agent/values.yaml
@@ -19,6 +19,9 @@ controller:
   cluster_id: ""
   cluster_name: ""
   externalIp_enable: false
+  # controller.localIp: Specify the agent IP address (useful when host has multiple IPs)
+  # If set, this IP will have the highest priority and will be used for all Agent-Box communications
+  localIp: ""
 
 # the image repository is related to the running env"
 images:

--- a/collector/kubernetes/pod.go
+++ b/collector/kubernetes/pod.go
@@ -323,6 +323,12 @@ func (pi *PodInfo) addLink(resource string, uid string) {
 }
 
 func (collector *PodCollector) setAgentExternalIp() {
+	// 如果用户已经通过 --localIp 参数指定了 IP，则不覆盖
+	if options.Opts.LocalIp != "" {
+		logrus.Debugf("Agent IP is already specified via --localIp flag: %s, skip setting from Service ExternalIP", options.Opts.LocalIp)
+		return
+	}
+
 	serviceInfos, _, err := collector.serviceCollector.getServiceInfo()
 	if err != nil {
 		logrus.Warnf("get service info failed, err: %v", err)


### PR DESCRIPTION
- Introduced a new `localIp` field in the `values.yaml` files for both chaos-agent and chaos-agent-arm, allowing users to specify the agent IP address when multiple IPs are available.
- Updated the `ahas_deployment.yaml` templates to include the `--localIp` flag, ensuring the specified IP is used in agent communications.
- Enhanced the `PodCollector` logic to respect the `--localIp` parameter, preventing it from being overridden by the service's external IP.

This change improves flexibility in agent IP configuration, particularly in complex networking environments.

Resolve chaosblade-io/chaosblade-box#172