### PR TITLE
fix: replace user.Current() with os.UserHomeDir() to avoid glibc crash

### DIFF
--- a/pkg/helm3/registry/cache.go
+++ b/pkg/helm3/registry/cache.go
@@ -129,7 +129,8 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 			numLayers := len(manifest.Layers)
 			if numLayers != 1 {
 				return &r, errors.New(
-					fmt.Sprintf("manifest does not contain exactly 1 layer (total: %d)", numLayers))
+					fmt.Sprintf("manifest does not contain exactly 1 layer (total: %d)", numLayers),
+				)
 			}
 			var contentLayer *ocispec.Descriptor
 			for _, layer := range manifest.Layers {
@@ -140,11 +141,13 @@ func (cache *Cache) FetchReference(ref *Reference) (*CacheRefSummary, error) {
 			}
 			if contentLayer == nil {
 				return &r, errors.New(
-					fmt.Sprintf("manifest does not contain a layer with mediatype %s", HelmChartContentLayerMediaType))
+					fmt.Sprintf("manifest does not contain a layer with mediatype %s", HelmChartContentLayerMediaType),
+				)
 			}
 			if contentLayer.Size == 0 {
 				return &r, errors.New(
-					fmt.Sprintf("manifest layer with mediatype %s is of size 0", HelmChartContentLayerMediaType))
+					fmt.Sprintf("manifest layer with mediatype %s is of size 0", HelmChartContentLayerMediaType),
+				)
 			}
 			r.ContentLayer = contentLayer
 			info, err := cache.ociStore.Info(ctx(cache.out, cache.debug), contentLayer.Digest)

--- a/pkg/helm3/registry/client.go
+++ b/pkg/helm3/registry/client.go
@@ -184,7 +184,8 @@ func (c *Client) PullChart(ref *Reference) (*bytes.Buffer, error) {
 	numLayers := len(layerDescriptors)
 	if numLayers < 1 {
 		return buf, errors.New(
-			fmt.Sprintf("manifest does not contain at least 1 layer (total: %d)", numLayers))
+			fmt.Sprintf("manifest does not contain at least 1 layer (total: %d)", numLayers),
+		)
 	}
 
 	var contentLayer *ocispec.Descriptor
@@ -199,7 +200,8 @@ func (c *Client) PullChart(ref *Reference) (*bytes.Buffer, error) {
 	if contentLayer == nil {
 		return buf, errors.New(
 			fmt.Sprintf("manifest does not contain a layer with mediatype %s",
-				HelmChartContentLayerMediaType))
+				HelmChartContentLayerMediaType),
+		)
 	}
 
 	_, b, ok := store.Get(*contentLayer)

--- a/pkg/helm3/registry/client_test.go
+++ b/pkg/helm3/registry/client_test.go
@@ -285,7 +285,8 @@ func initCompromisedRegistryTestServer() string {
       "size": 1
     }
   ]
-}`))
+}`,
+			))
 		} else if r.URL.Path == "/v2/testrepo/supposedlysafechart/blobs/sha256:a705ee2789ab50a5ba20930f246dbd5cc01ff9712825bb98f57ee8414377f133" {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(200)

--- a/pkg/tools/env.go
+++ b/pkg/tools/env.go
@@ -21,7 +21,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/user"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -63,9 +62,9 @@ var (
 
 // GetUserHome return user home.
 func GetUserHome() string {
-	user, err := user.Current()
+	home, err := os.UserHomeDir()
 	if err == nil {
-		return user.HomeDir
+		return home
 	}
 	return "/root"
 }


### PR DESCRIPTION
## Summary
- Replace `user.Current()` with `os.UserHomeDir()` in `GetUserHome()` to fix glibc dynamic linker assertion failure (`dl-call-libc-early-init.c:37`) on statically-linked or musl-based ARM64 containers
- `user.Current()` uses CGO to call `getpwuid_r`, which depends on glibc NSS modules that are unavailable in minimal/musl containers, causing repeated SIGABRT crash loops
- `os.UserHomeDir()` is a pure Go implementation that reads `$HOME` directly, avoiding the CGO dependency entirely

## Test plan
- [ ] Build the binary with `make build_linux` (amd64) and `make build_arm64` (arm64)
- [ ] Deploy to a musl-based or minimal container and verify the agent starts without glibc assertion failures
- [ ] Verify `GetUserHome()` returns the correct home directory path

🤖 Generated with [Claude Code](https://claude.com/claude-code)